### PR TITLE
Fixing a bug, branch stats reported as blocks

### DIFF
--- a/src/ReportGenerator.Core/Reporting/Builders/TeamCitySummaryReportBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/TeamCitySummaryReportBuilder.cs
@@ -48,7 +48,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
                 .ToList();
 
             WriteStatistics('S', summaryResult.CoveredLines, summaryResult.CoverableLines);
-            WriteStatistics('B', summaryResult.CoveredBranches.GetValueOrDefault(), summaryResult.TotalBranches.GetValueOrDefault());
+            WriteStatistics('R', summaryResult.CoveredBranches.GetValueOrDefault(), summaryResult.TotalBranches.GetValueOrDefault());
             WriteStatistics('C', allClasses.Count(y => y.CoveredLines > 0), allClasses.Count);
             WriteStatistics('M', summaryResult.CoveredCodeElements, summaryResult.TotalCodeElements);
         }


### PR DESCRIPTION
Branches stats should be reported with a PostFix of 'R' according to this https://www.jetbrains.com/help/teamcity/custom-chart.html#Default-Statistics-Values-Provided-by-TeamCity